### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -9,7 +9,7 @@
         "visualization stats"
     ],
     "description": "Analyse videos labeled for Action Recognition task",
-    "docker_image": "supervisely/visualization-stats:0.0.5",
+    "docker_image": "supervisely/visualization-stats:6.73.564",
     "main_script": "src/main.py",
     "gui_template": "src/gui.html",
     "task_location": "workspace_tasks",

--- a/config.json
+++ b/config.json
@@ -9,7 +9,7 @@
     "visualization stats"
   ],
   "description": "Analyse videos labeled for Action Recognition task",
-  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "docker_image": "supervisely/base-py-sdk:6.73.564",
   "main_script": "src/main.py",
   "gui_template": "src/gui.html",
   "task_location": "workspace_tasks",

--- a/config.json
+++ b/config.json
@@ -1,29 +1,29 @@
 {
-    "name": "Action Recognition Stats Tool",
-    "type": "app",
-    "categories": [
-        "videos",
-        "visualization",
-        "exploration",
-        "statistics",
-        "visualization stats"
+  "name": "Action Recognition Stats Tool",
+  "type": "app",
+  "categories": [
+    "videos",
+    "visualization",
+    "exploration",
+    "statistics",
+    "visualization stats"
+  ],
+  "description": "Analyse videos labeled for Action Recognition task",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "main_script": "src/main.py",
+  "gui_template": "src/gui.html",
+  "task_location": "workspace_tasks",
+  "need_gpu": false,
+  "gpu": "preferred",
+  "icon": "https://img.icons8.com/color/96/000000/rebalance-portfolio--v1.png",
+  "icon_cover": false,
+  "icon_background": "#FFFFFF",
+  "instance_version": "6.15.60",
+  "context_menu": {
+    "target": [
+      "videos_project"
     ],
-    "description": "Analyse videos labeled for Action Recognition task",
-    "docker_image": "supervisely/visualization-stats:6.73.564",
-    "main_script": "src/main.py",
-    "gui_template": "src/gui.html",
-    "task_location": "workspace_tasks",
-    "need_gpu": false,
-    "gpu": "preferred",
-    "icon": "https://img.icons8.com/color/96/000000/rebalance-portfolio--v1.png",
-    "icon_cover": false,
-    "icon_background": "#FFFFFF",
-    "instance_version": "6.15.60",
-    "context_menu": {
-        "target": [
-            "videos_project"
-        ],
-        "context_category": "Action Recognition"
-    },
-    "poster": "https://imgur.com/8Q7ldTU.png"
+    "context_category": "Action Recognition"
+  },
+  "poster": "https://imgur.com/8Q7ldTU.png"
 }

--- a/config.json
+++ b/config.json
@@ -18,7 +18,7 @@
     "icon": "https://img.icons8.com/color/96/000000/rebalance-portfolio--v1.png",
     "icon_cover": false,
     "icon_background": "#FFFFFF",
-    "instance_version": "6.4.21",
+    "instance_version": "6.15.60",
     "context_menu": {
         "target": [
             "videos_project"

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.72.70
+supervisely==6.73.564

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,4 @@
-import supervisely_lib as sly
+import supervisely as sly
 import ui.ui as ui
 
 import sly_globals as g

--- a/src/sly_globals.py
+++ b/src/sly_globals.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import sys
 import pickle
 
-import supervisely_lib as sly
+import supervisely as sly
 from sly_fields_names import ItemsStatusField
 
 import sly_functions as f

--- a/src/ui/combinations_matrix.py
+++ b/src/ui/combinations_matrix.py
@@ -6,7 +6,7 @@ import sly_globals as g
 import sly_functions as f
 import sly_constants as c
 
-import supervisely_lib as sly
+import supervisely as sly
 import timeline
 
 

--- a/src/ui/frame_information.py
+++ b/src/ui/frame_information.py
@@ -4,7 +4,7 @@ import time
 
 import sly_globals as g
 import sly_functions as f
-import supervisely_lib as sly
+import supervisely as sly
 
 
 def init_fields(state, data):

--- a/src/ui/input_project.py
+++ b/src/ui/input_project.py
@@ -1,6 +1,6 @@
 import pickle
 
-import supervisely_lib as sly
+import supervisely as sly
 
 import sly_globals as g
 import sly_functions as f

--- a/src/ui/pie_chart.py
+++ b/src/ui/pie_chart.py
@@ -6,7 +6,7 @@ import sly_globals as g
 import sly_functions as f
 import sly_constants as c
 
-import supervisely_lib as sly
+import supervisely as sly
 
 
 def init_fields(state, data):

--- a/src/ui/select_tags.py
+++ b/src/ui/select_tags.py
@@ -1,4 +1,4 @@
-import supervisely_lib as sly
+import supervisely as sly
 
 import sly_globals as g
 import sly_functions as f

--- a/src/ui/select_video.py
+++ b/src/ui/select_video.py
@@ -1,4 +1,4 @@
-import supervisely_lib as sly
+import supervisely as sly
 
 import sly_globals as g
 import sly_functions as f

--- a/src/ui/timeline.py
+++ b/src/ui/timeline.py
@@ -7,7 +7,7 @@ import sly_globals as g
 import sly_functions as f
 import sly_constants as c
 
-import supervisely_lib as sly
+import supervisely as sly
 
 from functools import lru_cache
 

--- a/src/ui/ui.py
+++ b/src/ui/ui.py
@@ -1,4 +1,4 @@
-import supervisely_lib as sly
+import supervisely as sly
 import sly_globals as g
 
 import input_project

--- a/src/ui/video_player.py
+++ b/src/ui/video_player.py
@@ -4,7 +4,7 @@ import time
 
 import sly_globals as g
 import sly_functions as f
-import supervisely_lib as sly
+import supervisely as sly
 
 
 def init_fields(state, data):


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
